### PR TITLE
Fix random status generator and add test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,5 +160,10 @@
 			</plugin>
 		</plugins>
 	</build>
-
+	<repositories>
+        <repository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
 </project>

--- a/src/main/java/ids/lambda/stream/StreamApplication.java
+++ b/src/main/java/ids/lambda/stream/StreamApplication.java
@@ -81,9 +81,8 @@ public class StreamApplication {
 				.getAsInt();
 		String so = "SO" + random.ints(200, 300).findFirst()
 				.getAsInt();
-		int rstatus = random.ints(0, 2).findFirst()
-				.getAsInt();
-		STATUS st = (rstatus == 2) ? STATUS.CREATED : (rstatus == 1) ? STATUS.UPDATED : STATUS.UPDATED;
+		STATUS[] statuses = STATUS.values();
+	STATUS st = statuses[random.nextInt(statuses.length)];
 
 		Payload p = new Payload(clin_id, so, st);
 		Source s = new Source(UUID.randomUUID(), Instant.now(), p);

--- a/src/test/java/ids/lambda/stream/StreamApplicationTests.java
+++ b/src/test/java/ids/lambda/stream/StreamApplicationTests.java
@@ -1,12 +1,39 @@
 package ids.lambda.stream;
 
-
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import poc.ids.streams.Payload;
+import poc.ids.streams.STATUS;
+import poc.ids.streams.Source;
 
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 class StreamApplicationTests {
 
+    @Autowired
+    private Supplier<Source> trigger;
 
-	
+    @Test
+    void shouldGenerateAllStatusTypes() {
+        // Repeatedly call the supplier to get a stream of Source objects
+        Set<STATUS> generatedStatuses = Stream.generate(trigger)
+                .limit(1000) // Call it 1000 times to have a high chance of getting all statuses
+                .map(source -> (Payload) source.get("EVENT"))
+                .map(payload -> (STATUS) payload.get("STATUS"))
+                .collect(Collectors.toSet());
+
+        // The set of all possible statuses
+        Set<STATUS> allStatuses = EnumSet.allOf(STATUS.class);
+
+        // Assert that the set of generated statuses is equal to the set of all possible statuses
+        assertThat(generatedStatuses).isEqualTo(allStatuses);
+    }
 }


### PR DESCRIPTION
The random status generator in `StreamApplication.java` was not generating all possible statuses. It was only generating `UPDATED` status. This was due to a flawed logic in the random number generation and the ternary operator.

This commit fixes the random status generator to correctly generate all possible statuses from the `STATUS` enum. It also adds a test case to verify that all statuses can be generated.

Additionally, the Confluent repository was added to the `pom.xml` to allow the project to build correctly.